### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 yupi>=0.12.0
 requests
-numpy
+numpy>=1.23
 patool
 scipy
 utm


### PR DESCRIPTION
Fixes initialization error caused with tensorflow (on my Mac) after `from pactus import Dataset, featurizers`:

```
File /usr/local/anaconda3/lib/python3.8/site-packages/tensorflow/python/client/pywrap_tf_session.py:19, in <module>
     17 # pylint: disable=invalid-import-order,g-bad-import-order, wildcard-import, unused-import
     18 from tensorflow.python import pywrap_tensorflow
---> 19 from tensorflow.python.client._pywrap_tf_session import *
     20 from tensorflow.python.client._pywrap_tf_session import _TF_SetTarget
     21 from tensorflow.python.client._pywrap_tf_session import _TF_SetConfig

ImportError: initialization failed
```

as suggested in https://stackoverflow.com/questions/73075027/recieving-error-when-importing-tensorflow.